### PR TITLE
dsp: asm: Avoid log spam for validation of payload size

### DIFF
--- a/sound/soc/msm/qdsp6v2/q6asm.c
+++ b/sound/soc/msm/qdsp6v2/q6asm.c
@@ -2169,37 +2169,37 @@ static int32_t q6asm_callback(struct apr_client_data *data, void *priv)
 		case ASM_DATA_CMD_REMOVE_TRAILING_SILENCE:
 		case ASM_SESSION_CMD_REGISTER_FOR_RX_UNDERFLOW_EVENTS:
 		case ASM_STREAM_CMD_OPEN_WRITE_COMPRESSED:
-			if (data->payload_size >=
-				2 * sizeof(uint32_t) &&
-				payload[1] != 0) {
-				pr_debug("%s: session %d opcode 0x%x token 0x%x Payload = [0x%x] stat 0x%x src %d dest %d\n",
-					__func__, ac->session,
-					data->opcode, data->token,
-					payload[0], payload[1],
-					data->src_port, data->dest_port);
-				pr_err("%s: cmd = 0x%x returned error = 0x%x\n",
-					__func__,
-					payload[0],
-					payload[1]);
-				if (wakeup_flag) {
-					if ((is_adsp_reg_event(payload[0]) >= 0)
-					|| (payload[0] ==
-					ASM_STREAM_CMD_SET_PP_PARAMS_V2)
-					|| (payload[0] ==
-					 ASM_STREAM_CMD_SET_PP_PARAMS_V3))
-						atomic_set(
-							&ac->cmd_state_pp,
-							payload[1]);
-					else
-						atomic_set(
-							&ac->cmd_state,
-							payload[1]);
-					wake_up(&ac->cmd_wait);
+			if (data->payload_size >= 2 * sizeof(uint32_t)) {
+				if (payload[1] != 0) {
+					pr_debug("%s: session %d opcode 0x%x token 0x%x Payload = [0x%x] stat 0x%x src %d dest %d\n",
+						__func__, ac->session,
+						data->opcode, data->token,
+						payload[0], payload[1],
+						data->src_port, data->dest_port);
+					pr_err("%s: cmd = 0x%x returned error = 0x%x\n",
+						__func__,
+						payload[0],
+						payload[1]);
+					if (wakeup_flag) {
+						if ((is_adsp_reg_event(payload[0]) >= 0)
+						|| (payload[0] ==
+						ASM_STREAM_CMD_SET_PP_PARAMS_V2)
+						|| (payload[0] ==
+						ASM_STREAM_CMD_SET_PP_PARAMS_V3))
+							atomic_set(
+								&ac->cmd_state_pp,
+								payload[1]);
+						else
+							atomic_set(
+								&ac->cmd_state,
+								payload[1]);
+						wake_up(&ac->cmd_wait);
+					}
+					spin_unlock_irqrestore(
+						&(session[session_id].session_lock),
+						flags);
+					return 0;
 				}
-				spin_unlock_irqrestore(
-					&(session[session_id].session_lock),
-					flags);
-				return 0;
 			} else {
 				pr_err("%s: payload size of %x is less than expected.\n",
 					__func__, data->payload_size);
@@ -2224,21 +2224,24 @@ static int32_t q6asm_callback(struct apr_client_data *data, void *priv)
 					(uint32_t *)data->payload, ac->priv);
 			break;
 		case ASM_CMD_ADD_TOPOLOGIES:
-			if (data->payload_size >=
-				2 * sizeof(uint32_t) &&
-				payload[1] != 0) {
-				pr_debug("%s:Payload = [0x%x]stat[0x%x]\n",
-					__func__, payload[0], payload[1]);
-				pr_err("%s: cmd = 0x%x returned error = 0x%x\n",
-					__func__, payload[0], payload[1]);
-				if (wakeup_flag) {
-					atomic_set(&ac->mem_state, payload[1]);
-					wake_up(&ac->mem_wait);
+			if (data->payload_size >= 2 * sizeof(uint32_t)) {
+				if (payload[1] != 0) {
+					pr_debug("%s:Payload = [0x%x]stat[0x%x]\n",
+						__func__, payload[0], payload[1]);
+					pr_err("%s: cmd = 0x%x returned error = 0x%x\n",
+						__func__, payload[0], payload[1]);
+					if (wakeup_flag) {
+						atomic_set(&ac->mem_state, payload[1]);
+						wake_up(&ac->mem_wait);
+					}
+					spin_unlock_irqrestore(
+						&(session[session_id].session_lock),
+						flags);
+					return 0;
 				}
-				spin_unlock_irqrestore(
-					&(session[session_id].session_lock),
-					flags);
-				return 0;
+			} else {
+				pr_err("%s: payload size of %x is less than expected.\n",
+					__func__, data->payload_size);
 			}
 			if (atomic_read(&ac->mem_state) && wakeup_flag) {
 				atomic_set(&ac->mem_state, 0);
@@ -2338,22 +2341,26 @@ static int32_t q6asm_callback(struct apr_client_data *data, void *priv)
 					flags);
 				return -EINVAL;
 			}
-			if (data->payload_size >= 2 * sizeof(uint32_t) &&
-				(lower_32_bits(port->buf[buf_index].phys) !=
-				payload[0] ||
-				msm_audio_populate_upper_32_bits(
-					port->buf[buf_index].phys) !=
-				payload[1])) {
-				pr_debug("%s: Expected addr %pK\n",
-				__func__, &port->buf[buf_index].phys);
-				pr_err("%s: rxedl[0x%x] rxedu [0x%x]\n",
-					__func__, payload[0], payload[1]);
-				spin_unlock_irqrestore(&port->dsp_lock,
-								dsp_flags);
-				spin_unlock_irqrestore(
-					&(session[session_id].session_lock),
-					flags);
-				return -EINVAL;
+			if (data->payload_size >= 2 * sizeof(uint32_t)) {
+				if ((lower_32_bits(port->buf[buf_index].phys) !=
+					payload[0] ||
+					msm_audio_populate_upper_32_bits(
+						port->buf[buf_index].phys) !=
+					payload[1])) {
+					pr_debug("%s: Expected addr %pK\n",
+					__func__, &port->buf[buf_index].phys);
+					pr_err("%s: rxedl[0x%x] rxedu [0x%x]\n",
+						__func__, payload[0], payload[1]);
+					spin_unlock_irqrestore(&port->dsp_lock,
+									dsp_flags);
+					spin_unlock_irqrestore(
+						&(session[session_id].session_lock),
+						flags);
+					return -EINVAL;
+				}
+			} else {
+				pr_err("%s: payload size of %x is less than expected.\n",
+					__func__, data->payload_size);
 			}
 			port->buf[buf_index].used = 1;
 			spin_unlock_irqrestore(&port->dsp_lock, dsp_flags);


### PR DESCRIPTION
On three occasions, the check of payload_size is combined with other checks. This results in errors for payload size being too small, when it is actually not the case.

Separate the check for paylod_size from other checks to avoid spamming the log for no (or at least not the right) reason.

Also added another instance of error reporting if payload_size is too small as it was missing.