### PR TITLE
uapi: Define __BITS_PER_LONG based on compiler target

### DIFF
--- a/arch/arm64/include/uapi/asm/bitsperlong.h
+++ b/arch/arm64/include/uapi/asm/bitsperlong.h
@@ -16,7 +16,11 @@
 #ifndef __ASM_BITSPERLONG_H
 #define __ASM_BITSPERLONG_H
 
+#ifdef __aarch64__
 #define __BITS_PER_LONG 64
+#else
+#define __BITS_PER_LONG 32
+#endif
 
 #include <asm-generic/bitsperlong.h>
 


### PR DESCRIPTION
We need this commit to solve the error of audio-caf when building LineageOS 16.0.
```
Werror=return-type -Wno-tautological-constant-compare -Wno-null-pointer-arithmetic -Wno-enum-compare -Wno-enum-compare-switch -MD -MF /home/sjll/los/los/out/target/product/maple/obj_arm/SHARED_LIBRARIES/audio.primary.msm8998_intermediates/audio_hw_extn_api.d -o /home/sjll/los/los/out/target/product/maple/obj_arm/SHARED_LIBRARIES/audio.primary.msm8998_intermediates/audio_hw_extn_api.o hardware/qcom/audio-caf/msm8998/hal/audio_hw_extn_api.c"
hardware/qcom/audio-caf/msm8998/hal/audio_hw_extn_api.c:328:62: error: format specifies type 'ssize_t' (aka 'int') but the argument has type 'ssize_t' (aka 'long') [-Werror,-Wformat]
            ALOGE("%s: error! write returned %zd", __func__, ret);
                                             ~~~             ^~~
                                             %zd
system/core/liblog/include/log/log_main.h:242:52: note: expanded from macro 'ALOGE'
#define ALOGE(...) ((void)ALOG(LOG_ERROR, LOG_TAG, __VA_ARGS__))
                                                   ^~~~~~~~~~~
system/core/liblog/include/log/log_main.h:308:67: note: expanded from macro 'ALOG'
#define ALOG(priority, tag, ...) LOG_PRI(ANDROID_##priority, tag, __VA_ARGS__)
                                                                  ^~~~~~~~~~~
system/core/liblog/include/log/log_main.h:72:69: note: expanded from macro 'LOG_PRI'
#define LOG_PRI(priority, tag, ...) android_printLog(priority, tag, __VA_ARGS__)
                                                                    ^~~~~~~~~~~
system/core/liblog/include/log/log_main.h:63:34: note: expanded from macro 'android_printLog'
  __android_log_print(prio, tag, __VA_ARGS__)
                                 ^~~~~~~~~~~
hardware/qcom/audio-caf/msm8998/hal/audio_hw_extn_api.c:333:59: error: format specifies type 'ssize_t' (aka 'int') but the argument has type 'ssize_t' (aka 'long') [-Werror,-Wformat]
              __func__, out->flags, bytes, bytes_written, ret, timestamp == NULL ? 0 : *timestamp);
                                                          ^~~
system/core/liblog/include/log/log_main.h:181:15: note: expanded from macro 'ALOGV'
      __ALOGV(__VA_ARGS__); \
              ^~~~~~~~~~~
system/core/liblog/include/log/log_main.h:176:56: note: expanded from macro '__ALOGV'
#define __ALOGV(...) ((void)ALOG(LOG_VERBOSE, LOG_TAG, __VA_ARGS__))
                                                       ^~~~~~~~~~~
system/core/liblog/include/log/log_main.h:308:67: note: expanded from macro 'ALOG'
#define ALOG(priority, tag, ...) LOG_PRI(ANDROID_##priority, tag, __VA_ARGS__)
                                                                  ^~~~~~~~~~~
system/core/liblog/include/log/log_main.h:72:69: note: expanded from macro 'LOG_PRI'
#define LOG_PRI(priority, tag, ...) android_printLog(priority, tag, __VA_ARGS__)
                                                                    ^~~~~~~~~~~
system/core/liblog/include/log/log_main.h:63:34: note: expanded from macro 'android_printLog'
  __android_log_print(prio, tag, __VA_ARGS__)
                                 ^~~~~~~~~~~
hardware/qcom/audio-caf/msm8998/hal/audio_hw_extn_api.c:337:59: error: format specifies type 'ssize_t' (aka 'int') but the argument has type 'ssize_t' (aka 'long') [-Werror,-Wformat]
              __func__, out->flags, bytes, bytes_written, ret);
                                                          ^~~
system/core/liblog/include/log/log_main.h:181:15: note: expanded from macro 'ALOGV'
      __ALOGV(__VA_ARGS__); \
              ^~~~~~~~~~~
system/core/liblog/include/log/log_main.h:176:56: note: expanded from macro '__ALOGV'
#define __ALOGV(...) ((void)ALOG(LOG_VERBOSE, LOG_TAG, __VA_ARGS__))
                                                       ^~~~~~~~~~~
system/core/liblog/include/log/log_main.h:308:67: note: expanded from macro 'ALOG'
#define ALOG(priority, tag, ...) LOG_PRI(ANDROID_##priority, tag, __VA_ARGS__)
                                                                  ^~~~~~~~~~~
system/core/liblog/include/log/log_main.h:72:69: note: expanded from macro 'LOG_PRI'
#define LOG_PRI(priority, tag, ...) android_printLog(priority, tag, __VA_ARGS__)
                                                                    ^~~~~~~~~~~
system/core/liblog/include/log/log_main.h:63:34: note: expanded from macro 'android_printLog'
  __android_log_print(prio, tag, __VA_ARGS__)
                                 ^~~~~~~~~~~
3 errors generated.
[  0% 22/27940] Building Kernel Config
make: Entering directory '/home/sjll/los/los/kernel/sony/msm8998'
make[1]: Entering directory '/home/sjll/los/los/out/target/product/maple/obj/KERNEL_OBJ'
  GEN     ./Makefile
drivers/input/misc/Kconfig:847:warning: ignoring type redefinition of 'FPC1145_PLATFORM' from 'boolean' to 'tristate'
drivers/input/misc/Kconfig:862:warning: leading whitespace ignored
#
# configuration written to .config
#
make[1]: Leaving directory '/home/sjll/los/los/out/target/product/maple/obj/KERNEL_OBJ'
make: Leaving directory '/home/sjll/los/los/kernel/sony/msm8998'
make: Entering directory '/home/sjll/los/los/kernel/sony/msm8998'
make[1]: Entering directory '/home/sjll/los/los/out/target/product/maple/obj/KERNEL_OBJ'
  GEN     ./Makefile
scripts/kconfig/conf  --savedefconfig=defconfig Kconfig
drivers/input/misc/Kconfig:847:warning: ignoring type redefinition of 'FPC1145_PLATFORM' from 'boolean' to 'tristate'
drivers/input/misc/Kconfig:862:warning: leading whitespace ignored
make[1]: Leaving directory '/home/sjll/los/los/out/target/product/maple/obj/KERNEL_OBJ'
make: Leaving directory '/home/sjll/los/los/kernel/sony/msm8998'
ninja: build stopped: subcommand failed.
14:56:21 ninja failed with: exit status 1

#### failed to build some targets (01:16 (mm:ss)) ####
```