### PR TITLE
dtsi: Disable wakeup_gesture_lpm_disabled for yoshino

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8998-yoshino-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8998-yoshino-common.dtsi
@@ -165,7 +165,7 @@
 			preset_y_max = <3839>;
 			preset_n_fingers = <10>;
 			wakeup_gesture_supported = <1>;
-			wakeup_gesture_lpm_disabled = <0>;
+			wakeup_gesture_lpm_disabled = <1>;
 			wakeup_gesture_timeout = <0>;
 			wakeup_gesture {
 				double_tap {


### PR DESCRIPTION
Without this, DT2W would no work reliably. For example, when toggling it off and back on again, it wouldn't work.

_However_, i believe this disables low power mode for clearpad. What results that might have on battery usage, I don't know (not using dt2w myself). But it works now.